### PR TITLE
Refactoring templates into their own files and reading content from variables to address Issue #1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+npm-debug.log
 /output
 /server

--- a/README.md
+++ b/README.md
@@ -22,24 +22,51 @@ npm start
 
 The files you'll likely edit are:
 
-* **`template/index.hbs`** : for the layout/copy of the email
-* **`template/style.css`** : for all your email-specific styles
-* **`template/variables.js`** : for the title, colors, and typography
+* **`src/index.hbs`** : for the layout of the email
+* **`src/style.css`** : for all your email-specific styles
+* **`src/variables.js`** : for the title, colors, and typography
 
-In `index.hbs`, there are several pre-made sections.  Basically, you'll
-copy-paste the sections you need and delete what you don't need.  Then, throw in
-your copy/images.  If you think of some other useful section, throw it it!
+In `index.hbs`, several pre-made sections are included.  Basically, you'll copy-paste the sections you need and delete what you don't need.  Then, throw in your copy/images.  If you think of some other useful section, throw it it!
 
-The base styles (e.g. typography and base font colors) can likely be set in
-`variables.js`.
+The base styles (e.g. typography and base font colors) can likely be set in `variables.js`. The content for pre-made sections is also stored here.
 
-Finally, whatever other styles you need can be set in style.css.  Note: because
-a CSS inlining process is being used, you can use several CSS3 selectors
-(e.g. :nth-of-type) to match certain elements. Because it's being inlined, you don't
-have to worry about client support _for selectors_.
+Finally, whatever other styles you need can be set in style.css.  Note: because a CSS inlining process is being used, you can use several CSS3 selectors (e.g. :nth-of-type) to match certain elements. Because it's being inlined, you don't have to worry about client support _for selectors_.
 
 Piece of 🍰!
 
+### Quick Example:
+
+index.hbs
+
+```hbs
+{{> start }}
+{{> header }}
+{{> end }}
+```
+
+variables.js
+
+```javascript
+module.exports = {
+  title: 'Title goes here',
+  /* other stuff */
+  header: {
+    text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.',
+    image: {
+      src: 'http://placehold.it/160x80',
+      alt_text: 'header image',
+    },
+    date: 'December 2, 2015'
+  },
+  /* more stuff */
+}
+```
+
+will output an `input.html` with just header section, with the text, image and date as defined above.
+
+*Note: If a pre-made section is added to the `index.hbs` without a corresponding setting in `variables.js`, it will not be rendered.*
+
+See [docs](docs/templates.md) for more details.
 
 ## Good Resources
 

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -11,14 +11,13 @@ image: {
   alt_text: '...'
 }
 ```
----
 
 ## header
 
 A simple header with text, image and date
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | text | header text | string | Lorem Ipsum |
 | image.src | header image source | link | /images/header_image.png |
 | image.alt_text | header image alt text | string | header image |
@@ -30,7 +29,7 @@ A simple header with text, image and date
 A main image, spanning across the width of the page
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | src | image source | link | /images/main_image.png |
 | alt_text | image alt text | string | this is an image |
 
@@ -40,7 +39,7 @@ A main image, spanning across the width of the page
 Two columns with image, text and a button
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | column1.text | text in column 1 | string | Lorem Ipsum |
 | column1.image.src | column 1 image source | string | /images/col1_image.png |
 | column1.image.alt_text | column 1 image alt text | string | col 1 image |
@@ -58,14 +57,14 @@ Two columns with image, text and a button
 A basic text block
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | text | simple text | string | Lorem Ipsum |
 
 
 ## text_button
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | text | simple text | string | Lorem Ipsum |
 | button.link | button link | link | http://google.com |
 | button.text | button text | string | A Button! |
@@ -76,7 +75,7 @@ A basic text block
 A highlighted text block with a highlighted button
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | text | simple text | string | Lorem Ipsum |
 | button.link | button link | link | http://google.com |
 | button.text | button text | string | We Must Act! |
@@ -87,7 +86,7 @@ A highlighted text block with a highlighted button
 Two columns with text
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | column1.text | text in column 1 | string | Lorem Ipsum |
 | column2.text | text in column 2 | string | Lorem Ipsum |
 
@@ -97,7 +96,7 @@ Two columns with text
 Text block with image on the left
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | text | text | string | Lorem Ipsum |
 | image.src | image source | link | /images/image.png |
 | image.alt_text | image alt text | string | left image |
@@ -108,7 +107,7 @@ Text block with image on the left
 Text block with image on the right
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | text | text | string | Lorem Ipsum |
 | image.src | image source | link | /images/image.png |
 | image.alt_text | image alt text | string | right image |
@@ -116,7 +115,7 @@ Text block with image on the right
 
 ## data_table
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | headers | items in the table header row |array of strings | ['Name', 'Date', 'Location'] |
 | data | rows in the table | array of array of strings | [ ['Event Name', '1-Jan-2014', 'New York, NY'], ['Another Name', '8-Jul-2014', 'Phoenix, AZ'], ['A Third Name', '21-Dec-2014', 'Seattle, WA'] ] |
 
@@ -126,6 +125,6 @@ Text block with image on the right
 A simple footer
 
 | param | description | type | example |
-| -- | -- | -- | -- |
+| --- | --- | --- | --- |
 | unsubscribe | unsubscribe text | string | Unsubscribe Instantly! |
 | webversion | webversion text | string | Desktop Version |

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -1,0 +1,131 @@
+# Templates
+
+The following templates/pre-made sections/partials are available for use. Each table contains the parameters that can be customized via `variables.js`
+
+*Params with dots denote nested params, e.g.*
+
+`image.src` and `image.alt_text` would be represented in `variables.js` as
+```javascript
+image: {
+  src: '...',
+  alt_text: '...'
+}
+```
+---
+
+## header
+
+A simple header with text, image and date
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| text | header text | string | Lorem Ipsum |
+| image.src | header image source | link | /images/header_image.png |
+| image.alt_text | header image alt text | string | header image |
+| date | header date | string | December 2, 2015 |
+
+
+## image
+
+A main image, spanning across the width of the page
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| src | image source | link | /images/main_image.png |
+| alt_text | image alt text | string | this is an image |
+
+
+## image_columns
+
+Two columns with image, text and a button
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| column1.text | text in column 1 | string | Lorem Ipsum |
+| column1.image.src | column 1 image source | string | /images/col1_image.png |
+| column1.image.alt_text | column 1 image alt text | string | col 1 image |
+| column1.button.link | column 1 button link | link | http://google.com |
+| column1.button.text | column 1 button text | string | A Button! |
+| column2.text | text in column 2 | string | Lorem Ipsum |
+| column2.image.src | column 2 image source | link | /images/col2_image.png |
+| column2.image.alt_text | column 2 image alt text | string | col 2 image |
+| column2.button.link | column 2 button link | string | http://google.com |
+| column2.button.text | column 2 button text | string | A Button! |
+
+
+## text_basic
+
+A basic text block
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| text | simple text | string | Lorem Ipsum |
+
+
+## text_button
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| text | simple text | string | Lorem Ipsum |
+| button.link | button link | link | http://google.com |
+| button.text | button text | string | A Button! |
+
+
+## text_call_to_action
+
+A highlighted text block with a highlighted button
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| text | simple text | string | Lorem Ipsum |
+| button.link | button link | link | http://google.com |
+| button.text | button text | string | We Must Act! |
+
+
+## text_columns
+
+Two columns with text
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| column1.text | text in column 1 | string | Lorem Ipsum |
+| column2.text | text in column 2 | string | Lorem Ipsum |
+
+
+## text_with_left_image
+
+Text block with image on the left
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| text | text | string | Lorem Ipsum |
+| image.src | image source | link | /images/image.png |
+| image.alt_text | image alt text | string | left image |
+
+
+## text_with_right_image
+
+Text block with image on the right
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| text | text | string | Lorem Ipsum |
+| image.src | image source | link | /images/image.png |
+| image.alt_text | image alt text | string | right image |
+
+
+## data_table
+| param | description | type | example |
+| -- | -- | -- | -- |
+| headers | items in the table header row |array of strings | ['Name', 'Date', 'Location'] |
+| data | rows in the table | array of array of strings | [ ['Event Name', '1-Jan-2014', 'New York, NY'], ['Another Name', '8-Jul-2014', 'Phoenix, AZ'], ['A Third Name', '21-Dec-2014', 'Seattle, WA'] ] |
+
+
+## footer
+
+A simple footer
+
+| param | description | type | example |
+| -- | -- | -- | -- |
+| unsubscribe | unsubscribe text | string | Unsubscribe Instantly! |
+| webversion | webversion text | string | Desktop Version |

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,11 +1,11 @@
 const browserSync = require('browser-sync').create()
 const fs = require('fs')
 const gulp = require('gulp')
+const reload = require('require-reload')(require)
 const handlebars = require('gulp-compile-handlebars')
 const inlineCss = require('gulp-inline-css')
 const rename = require('gulp-rename');
-const replace = require('gulp-replace')
-const variables = require('./src/variables');
+const replace = require('gulp-replace');
 const zip = require('gulp-zip')
 
 /* Package all our image assets into a zip file (e.g. for Campaign Monitor) */
@@ -19,6 +19,7 @@ gulp.task('zip-images', function () {
 
 /* Compile the email templates */
 gulp.task('templates', function () {
+  const variables = reload('./src/variables')
   const retainedStyles = fs.readFileSync('src/reset-retain.css')
   const compileOptions = {
     batch: ['src/partials']
@@ -46,7 +47,7 @@ gulp.task('watch', function () {
     }
   })
 
-  gulp.watch('src/*', ['templates'])
+  gulp.watch(['src/*', 'src/partials/*'], ['templates'])
   gulp.watch('src/images/*', ['zip-images'])
 })
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "gulp-inline-css": "^3.0.0",
     "gulp-rename": "^1.2.2",
     "gulp-replace": "^0.5.4",
-    "gulp-zip": "^3.0.2"
+    "gulp-zip": "^3.0.2",
+    "require-reload": "^0.2.2"
   }
 }

--- a/src/index.hbs
+++ b/src/index.hbs
@@ -1,25 +1,25 @@
-{{> start}}
+{{> start }}
 
-{{> header}}
+{{> header }}
 
-{{> image}}
+{{> image }}
 
-{{> text_basic}}
+{{> text_basic }}
 
-{{> text_call_to_action}}
+{{> text_call_to_action }}
 
-{{> text_button}}
+{{> text_button }}
 
-{{> text_columns}}
+{{> text_columns }}
 
-{{> image_columns}}
+{{> image_columns }}
 
-{{> text_with_left_image}}
+{{> text_with_left_image }}
 
-{{> text_with_right_image}}
+{{> text_with_right_image }}
 
-{{> data_table}}
+{{> data_table }}
 
-{{> footer}}
+{{> footer }}
 
-{{> end}}
+{{> end }}

--- a/src/index.hbs
+++ b/src/index.hbs
@@ -1,192 +1,25 @@
 {{> start}}
 
-<tr bgcolor="{{ brandPrimary }}">
-  <td style="text-align:center; padding:4%; font-family:{{ headingFontFamily }}; font-size:13px; line-height:1.2; color:{{ contrastingFontColor }}">
-    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
-      <tr>
-        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160x80" alt="alt text" width="160" height="80" border="0" align="center" /></td>
-        <td class="stack-column" width="4%" height="4%">&nbsp;</td>
-        <td class="stack-column" valign="top">
-          <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
-            <tr>
-              <td class="stack-column" align="left">
-                <p style="font-size:18px; font-weight:bold; margin:0">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
-              </td>
-            </tr>
-            <tr>
-              <td class="stack-column" align="right">December 2, 2015</td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </td>
-</tr>
+{{> header}}
 
-<tr>
-  <td valign="middle" align="center"><img class="fluid" src="http://placehold.it/{{ emailWidth }}x300" alt="alt text" width="{{ emailWidth }}" height="300" align="center" border="0" style="margin: auto" /></td>
-</tr>
+{{> image}}
 
-<tr>
-  <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
-    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
-    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
-    malesuada fames ac turpis egestas.
-  </td>
-</tr>
+{{> text_basic}}
 
-<tr>
-  <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ contrastingFontColor }}; background-color: {{ brandPrimary }}">
-    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
-    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
-    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
-    malesuada fames ac turpis egestas.
-    <br/><br/>
+{{> text_call_to_action}}
 
-    <table class="button" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto">
-      <tr>
-        <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 1px solid {{ backgroundAltColor }}; padding: 15px 25px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->This is a call to action<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
-      </tr>
-    </table>
-  </td>
-</tr>
+{{> text_button}}
 
-<tr>
-  <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}; background-color: {{ backgroundAltColor }}">
-    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
-    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
-    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
-    malesuada fames ac turpis egestas.
+{{> text_columns}}
 
-    <table class="button" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto">
-      <tr>
-        <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center">
-          <a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px">
-            <b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b>
-          </a>
-        </td>
-      </tr>
-    </table>
-  </td>
-</tr>
+{{> image_columns}}
 
-<tr>
-  <td>
-    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
-      <tr>
-        <td style="padding: 0 4%">
-          <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
-            <tr>
-              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
-              </td>
+{{> text_with_left_image}}
 
-              <td class="stack-column" width="4%" height="4%">&nbsp;</td>
+{{> text_with_right_image}}
 
-              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </td>
-</tr>
+{{> data_table}}
 
-<tr>
-  <td>
-    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
-      <tr>
-        <td style="padding: 0 4%">
-          <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
-            <tr>
-              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /><br/><br/>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.<br/><br/>
-                <table class="button" cellspacing="0"
-                  cellpadding="0" border="0" align="center" style="margin: auto">
-                  <tr>
-                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
-                  </tr>
-                </table>
-              </td>
-              <td class="stack-column" width="4%" height="4%">&nbsp;</td>
-              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /><br/><br/>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.<br/><br/>
-                <table class="button" cellspacing="0"
-                  cellpadding="0" border="0" align="center" style="margin: auto">
-                  <tr>
-                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
-                  </tr>
-                </table>
-              </td>
-            </tr>
-          </table>
-        </td>
-      </tr>
-    </table>
-  </td>
-</tr>
-
-<tr>
-  <td style="padding: 4%">
-    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
-      <tr>
-        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /></td>
-        <td class="stack-column" width="4%" height="4%">&nbsp;</td>
-        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo.<br/><br/>Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit.
-          Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</td>
-      </tr>
-    </table>
-  </td>
-</tr>
-
-<tr>
-  <td style="padding: 4%">
-    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
-      <tr>
-        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo.<br/><br/>Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit.
-          Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</td>
-        <td class="stack-column" width="4%" height="4%">&nbsp;</td>
-        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /></td>
-      </tr>
-    </table>
-  </td>
-</tr>
-
-<tr>
-  <td width="92%" style="padding: 4%">
-    <table cellspacing="0" cellpadding="0" border="0" width="100%">
-      <tr>
-        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Name</td>
-        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Date</td>
-        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Location</td>
-      </tr>
-      <tr>
-        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Event Name</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">1-Jan-2014</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">New York, NY</td>
-        <td class="data-table-mobile-divider" style="display: none"></td>
-      </tr>
-      <tr>
-        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Another Name</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">8-Jul-2014</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Phoenix, AZ</td>
-        <td class="data-table-mobile-divider" style="display: none"></td>
-      </tr>
-      <tr>
-        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">A Third Name</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">21-Dec-2014</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Seattle, WA</td>
-        <td class="data-table-mobile-divider" style="display: none"></td>
-      </tr>
-    </table>
-  </td>
-</tr>
-
-<tr bgcolor="{{ brandPrimary }}">
-  <td style="text-align:center; padding:4% 0; font-family:{{ baseFontFamily }}; font-size:13px; line-height:1.2; color:{{ contrastingFontColor }}">Is this email not displaying correctly? Try the
-    <webversion style="color:{{ contrastingFontColor }}; text-decoration:underline">web version</webversion>. Not interested anymore?
-    <unsubscribe style="color:{{ contrastingFontColor }}; text-decoration:underline">Unsubscribe instantly</unsubscribe>.</td>
-</tr>
+{{> footer}}
 
 {{> end}}

--- a/src/partials/data_table.hbs
+++ b/src/partials/data_table.hbs
@@ -1,29 +1,26 @@
+{{#if data_table}}
 <tr>
   <td width="92%" style="padding: 4%">
     <table cellspacing="0" cellpadding="0" border="0" width="100%">
+      {{#if data_table.headers}}
       <tr>
-        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Name</td>
-        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Date</td>
-        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Location</td>
+        {{#each data_table.headers}}
+        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ ../baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ ../baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">{{this}}</td>
+        {{/each}}
       </tr>
+      {{/if}}
+
+      {{#if data_table.data}}
+      {{#each data_table.data}}
       <tr>
-        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Event Name</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">1-Jan-2014</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">New York, NY</td>
+        {{#each this}}
+        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ ../../baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ ../../baseFontColor }}; border-bottom: 1px solid #eeeeee">{{this}}</td>
+        {{/each}}
         <td class="data-table-mobile-divider" style="display: none"></td>
       </tr>
-      <tr>
-        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Another Name</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">8-Jul-2014</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Phoenix, AZ</td>
-        <td class="data-table-mobile-divider" style="display: none"></td>
-      </tr>
-      <tr>
-        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">A Third Name</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">21-Dec-2014</td>
-        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Seattle, WA</td>
-        <td class="data-table-mobile-divider" style="display: none"></td>
-      </tr>
+      {{/each}}
+      {{/if}}
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/partials/data_table.hbs
+++ b/src/partials/data_table.hbs
@@ -1,0 +1,29 @@
+<tr>
+  <td width="92%" style="padding: 4%">
+    <table cellspacing="0" cellpadding="0" border="0" width="100%">
+      <tr>
+        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Name</td>
+        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Date</td>
+        <td class="data-table-th" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; font-weight: bold; border-bottom: 1px solid #cccccc">Location</td>
+      </tr>
+      <tr>
+        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Event Name</td>
+        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">1-Jan-2014</td>
+        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">New York, NY</td>
+        <td class="data-table-mobile-divider" style="display: none"></td>
+      </tr>
+      <tr>
+        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Another Name</td>
+        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">8-Jul-2014</td>
+        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Phoenix, AZ</td>
+        <td class="data-table-mobile-divider" style="display: none"></td>
+      </tr>
+      <tr>
+        <td class="data-table-td-title" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">A Third Name</td>
+        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">21-Dec-2014</td>
+        <td class="data-table-td" valign="top" align="left" style="padding: 10px 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; border-bottom: 1px solid #eeeeee">Seattle, WA</td>
+        <td class="data-table-mobile-divider" style="display: none"></td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -1,0 +1,5 @@
+<tr bgcolor="{{ brandPrimary }}">
+  <td style="text-align:center; padding:4% 0; font-family:{{ baseFontFamily }}; font-size:13px; line-height:1.2; color:{{ contrastingFontColor }}">Is this email not displaying correctly? Try the
+    <webversion style="color:{{ contrastingFontColor }}; text-decoration:underline">web version</webversion>. Not interested anymore?
+    <unsubscribe style="color:{{ contrastingFontColor }}; text-decoration:underline">Unsubscribe instantly</unsubscribe>.</td>
+</tr>

--- a/src/partials/footer.hbs
+++ b/src/partials/footer.hbs
@@ -1,5 +1,7 @@
+{{#if footer}}
 <tr bgcolor="{{ brandPrimary }}">
   <td style="text-align:center; padding:4% 0; font-family:{{ baseFontFamily }}; font-size:13px; line-height:1.2; color:{{ contrastingFontColor }}">Is this email not displaying correctly? Try the
-    <webversion style="color:{{ contrastingFontColor }}; text-decoration:underline">web version</webversion>. Not interested anymore?
-    <unsubscribe style="color:{{ contrastingFontColor }}; text-decoration:underline">Unsubscribe instantly</unsubscribe>.</td>
+    <webversion style="color:{{ contrastingFontColor }}; text-decoration:underline">{{footer.webversion}}</webversion>. Not interested anymore?
+    <unsubscribe style="color:{{ contrastingFontColor }}; text-decoration:underline">{{footer.unsubsribe}}</unsubscribe>.</td>
 </tr>
+{{/if}}

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -3,8 +3,8 @@
   <td style="text-align:center; padding:4%; font-family:{{ headingFontFamily }}; font-size:13px; line-height:1.2; color:{{ contrastingFontColor }}">
     <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
       <tr>
-        {{#if header.img}}
-        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="{{header.img}}" alt="alt text" width="160" height="80" border="0" align="center" /></td>
+        {{#if header.image}}
+        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="{{header.image.src}}" alt="{{header.image.alt_text}}" width="160" height="80" border="0" align="center" /></td>
         {{/if}}
         <td class="stack-column" width="4%" height="4%">&nbsp;</td>
         <td class="stack-column" valign="top">

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -1,0 +1,22 @@
+<tr bgcolor="{{ brandPrimary }}">
+  <td style="text-align:center; padding:4%; font-family:{{ headingFontFamily }}; font-size:13px; line-height:1.2; color:{{ contrastingFontColor }}">
+    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
+      <tr>
+        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160x80" alt="alt text" width="160" height="80" border="0" align="center" /></td>
+        <td class="stack-column" width="4%" height="4%">&nbsp;</td>
+        <td class="stack-column" valign="top">
+          <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
+            <tr>
+              <td class="stack-column" align="left">
+                <p style="font-size:18px; font-weight:bold; margin:0">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+              </td>
+            </tr>
+            <tr>
+              <td class="stack-column" align="right">December 2, 2015</td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/header.hbs
+++ b/src/partials/header.hbs
@@ -1,22 +1,30 @@
+{{#if header}}
 <tr bgcolor="{{ brandPrimary }}">
   <td style="text-align:center; padding:4%; font-family:{{ headingFontFamily }}; font-size:13px; line-height:1.2; color:{{ contrastingFontColor }}">
     <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
       <tr>
-        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160x80" alt="alt text" width="160" height="80" border="0" align="center" /></td>
+        {{#if header.img}}
+        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="{{header.img}}" alt="alt text" width="160" height="80" border="0" align="center" /></td>
+        {{/if}}
         <td class="stack-column" width="4%" height="4%">&nbsp;</td>
         <td class="stack-column" valign="top">
           <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
+            {{#if header.text}}
             <tr>
               <td class="stack-column" align="left">
-                <p style="font-size:18px; font-weight:bold; margin:0">Lorem ipsum dolor sit amet, consectetur adipisicing elit.</p>
+                <p style="font-size:18px; font-weight:bold; margin:0">{{header.text}}</p>
               </td>
             </tr>
+            {{/if}}
+            {{#if header.date}}
             <tr>
-              <td class="stack-column" align="right">December 2, 2015</td>
+              <td class="stack-column" align="right">{{header.date}}</td>
             </tr>
+            {{/if}}
           </table>
         </td>
       </tr>
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/partials/image.hbs
+++ b/src/partials/image.hbs
@@ -1,0 +1,3 @@
+<tr>
+  <td valign="middle" align="center"><img class="fluid" src="http://placehold.it/{{ emailWidth }}x300" alt="alt text" width="{{ emailWidth }}" height="300" align="center" border="0" style="margin: auto" /></td>
+</tr>

--- a/src/partials/image.hbs
+++ b/src/partials/image.hbs
@@ -1,3 +1,5 @@
+{{#if image}}
 <tr>
-  <td valign="middle" align="center"><img class="fluid" src="http://placehold.it/{{ emailWidth }}x300" alt="alt text" width="{{ emailWidth }}" height="300" align="center" border="0" style="margin: auto" /></td>
+  <td valign="middle" align="center"><img class="fluid" src="{{image.src}}" alt="{{image.alt_text}}" width="{{ emailWidth }}" height="300" align="center" border="0" style="margin: auto" /></td>
 </tr>
+{{/if}}

--- a/src/partials/image_columns.hbs
+++ b/src/partials/image_columns.hbs
@@ -1,3 +1,4 @@
+{{#if image_columns}}
 <tr>
   <td>
     <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
@@ -5,20 +6,19 @@
         <td style="padding: 0 4%">
           <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
             <tr>
-              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /><br/><br/>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.<br/><br/>
+              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="{{image_columns.column1.image.src}}" alt="{{image_columns.column1.image.alt_text}}" width="160" height="160" border="0" align="center" /><br/><br/>{{image_columns.column1.text}}<br/><br/>
                 <table class="button" cellspacing="0"
                   cellpadding="0" border="0" align="center" style="margin: auto">
                   <tr>
-                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
+                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="{{image_columns.column1.button.link}}" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->{{image_columns.column1.button.text}}<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
                   </tr>
                 </table>
               </td>
               <td class="stack-column" width="4%" height="4%">&nbsp;</td>
-              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /><br/><br/>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.<br/><br/>
-                <table class="button" cellspacing="0"
+              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="{{image_columns.column2.image.src}}" alt="{{image_columns.column2.image.alt_text}}" width="160" height="160" border="0" align="center" /><br/><br/>{{image_columns.column2.text}}<br/><br/>                <table class="button" cellspacing="0"
                   cellpadding="0" border="0" align="center" style="margin: auto">
                   <tr>
-                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
+                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="{{image_columns.column2.button.link}}" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->{{image_columns.column2.button.text}}<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
                   </tr>
                 </table>
               </td>
@@ -29,3 +29,4 @@
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/partials/image_columns.hbs
+++ b/src/partials/image_columns.hbs
@@ -1,0 +1,31 @@
+<tr>
+  <td>
+    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
+      <tr>
+        <td style="padding: 0 4%">
+          <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
+            <tr>
+              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /><br/><br/>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.<br/><br/>
+                <table class="button" cellspacing="0"
+                  cellpadding="0" border="0" align="center" style="margin: auto">
+                  <tr>
+                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
+                  </tr>
+                </table>
+              </td>
+              <td class="stack-column" width="4%" height="4%">&nbsp;</td>
+              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: center"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /><br/><br/>Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.<br/><br/>
+                <table class="button" cellspacing="0"
+                  cellpadding="0" border="0" align="center" style="margin: auto">
+                  <tr>
+                    <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
+                  </tr>
+                </table>
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/text_basic.hbs
+++ b/src/partials/text_basic.hbs
@@ -1,0 +1,8 @@
+<tr>
+  <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
+    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
+    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
+    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
+    malesuada fames ac turpis egestas.
+  </td>
+</tr>

--- a/src/partials/text_basic.hbs
+++ b/src/partials/text_basic.hbs
@@ -1,8 +1,8 @@
+{{#if text_basic}}
 <tr>
   <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
-    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
-    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
-    malesuada fames ac turpis egestas.
+    {{text_basic}}
   </td>
 </tr>
+
+{{/if}}

--- a/src/partials/text_basic.hbs
+++ b/src/partials/text_basic.hbs
@@ -1,7 +1,7 @@
 {{#if text_basic}}
 <tr>
   <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-    {{text_basic}}
+    {{text_basic.text}}
   </td>
 </tr>
 

--- a/src/partials/text_button.hbs
+++ b/src/partials/text_button.hbs
@@ -1,18 +1,16 @@
+{{#if text_button}}
 <tr>
   <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}; background-color: {{ backgroundAltColor }}">
-    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
-    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
-    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
-    malesuada fames ac turpis egestas.
-
+    {{text_button.text}}
     <table class="button" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto">
       <tr>
         <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center">
-          <a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px">
-            <b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b>
+          <a href="{{text_button.button.link}}" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px">
+            <b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->{{text_button.button.text}}<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b>
           </a>
         </td>
       </tr>
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/partials/text_button.hbs
+++ b/src/partials/text_button.hbs
@@ -1,0 +1,18 @@
+<tr>
+  <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}; background-color: {{ backgroundAltColor }}">
+    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
+    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
+    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
+    malesuada fames ac turpis egestas.
+
+    <table class="button" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto">
+      <tr>
+        <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center">
+          <a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 15px solid {{ brandPrimary }}; padding: 0 10px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px">
+            <b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->A Button<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b>
+          </a>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/text_call_to_action.hbs
+++ b/src/partials/text_call_to_action.hbs
@@ -1,0 +1,15 @@
+<tr>
+  <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ contrastingFontColor }}; background-color: {{ brandPrimary }}">
+    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
+    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
+    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
+    malesuada fames ac turpis egestas.
+    <br/><br/>
+
+    <table class="button" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto">
+      <tr>
+        <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 1px solid {{ backgroundAltColor }}; padding: 15px 25px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->This is a call to action<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/text_call_to_action.hbs
+++ b/src/partials/text_call_to_action.hbs
@@ -1,15 +1,14 @@
+{{#if text_call_to_action}}
 <tr>
   <td class="fluid-row" style="font-family: {{ baseFontFamily }}; color: {{ contrastingFontColor }}; background-color: {{ brandPrimary }}">
-    Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit,
-    urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus
-    et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et
-    malesuada fames ac turpis egestas.
+    {{text_call_to_action.text}}
     <br/><br/>
 
     <table class="button" cellspacing="0" cellpadding="0" border="0" align="center" style="margin: auto">
       <tr>
-        <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="http://www.google.com" style="background: {{ brandPrimary }}; border: 1px solid {{ backgroundAltColor }}; padding: 15px 25px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->This is a call to action<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
+        <td style="border-radius: 3px; background: {{ brandPrimary }}; text-align: center"><a href="{{text_call_to_action.button.link}}" style="background: {{ brandPrimary }}; border: 1px solid {{ backgroundAltColor }}; padding: 15px 25px; color: {{ contrastingFontColor }}; font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1; text-align: center; text-decoration: none; display: block; border-radius: 3px"><b><!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]-->{{text_call_to_action.button.text}}<!--[if mso]>&nbsp;&nbsp;&nbsp;&nbsp;<![endif]--></b></a></td>
       </tr>
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/partials/text_columns.hbs
+++ b/src/partials/text_columns.hbs
@@ -1,3 +1,4 @@
+{{#if text_columns}}
 <tr>
   <td>
     <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
@@ -6,13 +7,13 @@
           <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
             <tr>
               <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+                {{text_columns.column1}}
               </td>
 
               <td class="stack-column" width="4%" height="4%">&nbsp;</td>
 
               <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+                {{text_columns.column2}}
               </td>
             </tr>
           </table>
@@ -21,3 +22,4 @@
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/partials/text_columns.hbs
+++ b/src/partials/text_columns.hbs
@@ -7,13 +7,13 @@
           <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
             <tr>
               <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-                {{text_columns.column1}}
+                {{text_columns.column1.text}}
               </td>
 
               <td class="stack-column" width="4%" height="4%">&nbsp;</td>
 
               <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
-                {{text_columns.column2}}
+                {{text_columns.column2.text}}
               </td>
             </tr>
           </table>

--- a/src/partials/text_columns.hbs
+++ b/src/partials/text_columns.hbs
@@ -1,0 +1,23 @@
+<tr>
+  <td>
+    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
+      <tr>
+        <td style="padding: 0 4%">
+          <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center">
+            <tr>
+              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+              </td>
+
+              <td class="stack-column" width="4%" height="4%">&nbsp;</td>
+
+              <td class="stack-column" valign="top" width="48%" style="padding: 4% 0; font-family: {{ baseFontFamily }}; color: {{ baseFontColor }}">
+                Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/text_with_left_image.hbs
+++ b/src/partials/text_with_left_image.hbs
@@ -1,0 +1,12 @@
+<tr>
+  <td style="padding: 4%">
+    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
+      <tr>
+        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /></td>
+        <td class="stack-column" width="4%" height="4%">&nbsp;</td>
+        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo.<br/><br/>Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit.
+          Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/text_with_left_image.hbs
+++ b/src/partials/text_with_left_image.hbs
@@ -1,12 +1,13 @@
+{{#if text_with_left_image}}
 <tr>
   <td style="padding: 4%">
     <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
       <tr>
         <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /></td>
         <td class="stack-column" width="4%" height="4%">&nbsp;</td>
-        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo.<br/><br/>Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit.
-          Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</td>
+        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">{{text_with_left_image.text}}</td>
       </tr>
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/partials/text_with_right_image.hbs
+++ b/src/partials/text_with_right_image.hbs
@@ -1,0 +1,12 @@
+<tr>
+  <td style="padding: 4%">
+    <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
+      <tr>
+        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo.<br/><br/>Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit.
+          Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</td>
+        <td class="stack-column" width="4%" height="4%">&nbsp;</td>
+        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /></td>
+      </tr>
+    </table>
+  </td>
+</tr>

--- a/src/partials/text_with_right_image.hbs
+++ b/src/partials/text_with_right_image.hbs
@@ -1,12 +1,13 @@
+{{#if text_with_right_image}}
 <tr>
   <td style="padding: 4%">
     <table border="0" width="100%" cellpadding="0" cellspacing="0" align="center" dir="ltr">
       <tr>
-        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo.<br/><br/>Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit.
-          Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.</td>
+        <td class="stack-column-center" valign="top" style="font-family: {{ baseFontFamily }}; font-size: 15px; line-height: 1.3; color: {{ baseFontColor }}; text-align: left" dir="ltr">{{text_with_right_image.text}}</td>
         <td class="stack-column" width="4%" height="4%">&nbsp;</td>
-        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="http://placehold.it/160" alt="alt text" width="160" height="160" border="0" align="center" /></td>
+        <td class="stack-column-center" valign="top" width="160" dir="ltr"><img src="{{text_with_right_image.image.src}}" alt="{{text_with_right_image.image.alt_text}}" width="160" height="160" border="0" align="center" /></td>
       </tr>
     </table>
   </td>
 </tr>
+{{/if}}

--- a/src/variables.js
+++ b/src/variables.js
@@ -54,7 +54,9 @@ module.exports = {
 		},
 	},
 
-	text_basic: 'Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+	text_basic: {
+		text: 'Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.'
+	},
 
 	text_button: {
 		text: 'Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',

--- a/src/variables.js
+++ b/src/variables.js
@@ -14,22 +14,26 @@ module.exports = {
 	baseFontFamily: 'Trebuchet MS, Helvetica Neue, Helvetica, Arial, sans-serif',
 	headingFontFamily: 'Georgia, serif',
 
+	/* the next keys correspond to the pre-made sections/partials */
 	header: {
 		text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.',
-		img: 'http://placehold.it/160x80',
+		image: {
+			src: 'http://placehold.it/160x80',
+			alt_text: 'header image'
+		},
 		date: 'December 2, 2015'
 	},
 
 	image: {
 		src: 'http://placehold.it/600x300',
-		alt_text: 'alt text'
+		alt_text: 'main image'
 	},
 
 	image_columns: {
 		column1: {
 			image: {
 				src: 'http://placehold.it/160',
-				alt_text: 'alt text column 1'
+				alt_text: 'column 1 image'
 			},
 			text: 'Column1 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.',
 			button: {
@@ -40,7 +44,7 @@ module.exports = {
 		column2: {
 			image: {
 				src: 'http://placehold.it/160',
-				alt_text: 'alt text column 2'
+				alt_text: 'column 2 image'
 			},
 			text: 'Column2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.',
 			button: {
@@ -73,6 +77,22 @@ module.exports = {
 		column2: 'Column2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.'
 	},
 
+	text_with_left_image: {
+		text: 'Left Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+		image: {
+			src: 'http://placehold.it/160',
+			alt_text: 'text with image on left'
+		}
+	},
+
+	text_with_right_image: {
+		text: 'Right Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+		image: {
+			src: 'http://placehold.it/160',
+			alt_text: 'text with image on right'
+		}
+	},
+
 	data_table: {
 		headers: ['Name', 'Date', 'Location'],
 		data: [
@@ -86,20 +106,4 @@ module.exports = {
 		unsubsribe: 'Unsubcribe Instantly',
 		webversion: 'web version',
 	},
-
-	text_with_left_image: {
-		text: 'Left Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
-		image: {
-			src: 'http://placehold.it/160',
-			alt_text: 'alt text'
-		}
-	},
-
-	text_with_right_image: {
-		text: 'Right Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
-		image: {
-			src: 'http://placehold.it/160',
-			alt_text: 'alt text'
-		}
-	}
 }

--- a/src/variables.js
+++ b/src/variables.js
@@ -75,8 +75,12 @@ module.exports = {
 	},
 
 	text_columns: {
-		column1: 'Column1 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.',
-		column2: 'Column2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.'
+		column1: {
+			text: 'Column1 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.'
+		},
+		column2: {
+			text: 'Column2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.'
+		}
 	},
 
 	text_with_left_image: {

--- a/src/variables.js
+++ b/src/variables.js
@@ -12,5 +12,94 @@ module.exports = {
 	contrastingFontColor: '#f0f0f0',
 
 	baseFontFamily: 'Trebuchet MS, Helvetica Neue, Helvetica, Arial, sans-serif',
-	headingFontFamily: 'Georgia, serif'
+	headingFontFamily: 'Georgia, serif',
+
+	header: {
+		text: 'Lorem ipsum dolor sit amet, consectetur adipisicing elit.',
+		img: 'http://placehold.it/160x80',
+		date: 'December 2, 2015'
+	},
+
+	image: {
+		src: 'http://placehold.it/600x300',
+		alt_text: 'alt text'
+	},
+
+	image_columns: {
+		column1: {
+			image: {
+				src: 'http://placehold.it/160',
+				alt_text: 'alt text column 1'
+			},
+			text: 'Column1 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.',
+			button: {
+				link: 'http://google.com',
+				text: 'A Button Column 1'
+			}
+		},
+		column2: {
+			image: {
+				src: 'http://placehold.it/160',
+				alt_text: 'alt text column 2'
+			},
+			text: 'Column2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.',
+			button: {
+				link: 'http://google.com',
+				text: 'A Button Column 2'
+			}
+		},
+	},
+
+	text_basic: 'Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+
+	text_button: {
+		text: 'Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+		button: {
+			link: 'http://google.com',
+			text: 'A Button!'
+		}
+	},
+
+	text_call_to_action: {
+		text: 'Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+		button: {
+			link: 'http://google.com',
+			text: 'This is a call to action!'
+		}
+	},
+
+	text_columns: {
+		column1: 'Column1 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.',
+		column2: 'Column2 Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor.'
+	},
+
+	data_table: {
+		headers: ['Name', 'Date', 'Location'],
+		data: [
+			['Event Name', '1-Jan-2014', 'New York, NY'],
+			['Another Name', '8-Jul-2014', 'Phoenix, AZ'],
+			['A Third Name', '21-Dec-2014', 'Seattle, WA']
+		]
+	},
+
+	footer: {
+		unsubsribe: 'Unsubcribe Instantly',
+		webversion: 'web version',
+	},
+
+	text_with_left_image: {
+		text: 'Left Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+		image: {
+			src: 'http://placehold.it/160',
+			alt_text: 'alt text'
+		}
+	},
+
+	text_with_right_image: {
+		text: 'Right Ulla nec est tristique, tempor lacus eu, aliquam erat. Cras tristique, arcu ac tristique hendrerit, urna diam mollis libero, vitae gravida nisi lectus in leo. Aenean eu ligula id nisi euismod dapibus et eu mauris. Donec quis dictum velit. Pellentesque habitant morbi tristique senectus et netus et malesuada fames ac turpis egestas.',
+		image: {
+			src: 'http://placehold.it/160',
+			alt_text: 'alt text'
+		}
+	}
 }


### PR DESCRIPTION
Ideally, I would've liked to do something like

```
{{> header text="Lorem ipsum" img="/image/image.png" date="December 2, 2015" }}
```

but this approach seems to falter when attempting to pass in an array (as in the case of the data table).

I've basically written the templates to take content from the variables file (where arrays pose no issues).

---

Other changes:
- added hot reload when changing something in the partials directory or in `variables.js` (JS `require` apparently caches the variables fetch from the file, requiring the use of `require-reload`
- Updated readme, and added a new `templates` doc to explain the different partials

If there's a better/more appropriate way to pass array params (or a better approach for tables altogether), I can integrate that and update this PR.
